### PR TITLE
fix: add retry logic for Kalshi API rate limits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "prediction-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.3",
+        "exponential-backoff": "^3.1.3",
         "kalshi-typescript": "^3.0.0",
         "pino": "^10.1.0",
         "pino-pretty": "^13.1.3",
@@ -223,6 +224,8 @@
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
     "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.24.3",
+    "exponential-backoff": "^3.1.3",
     "kalshi-typescript": "^3.0.0",
     "pino": "^10.1.0",
     "pino-pretty": "^13.1.3",


### PR DESCRIPTION
## Summary

- Add `exponential-backoff` package to handle API rate limiting
- Wrap all KalshiClient API methods with retry logic for 429 errors
- Uses exponential backoff with jitter to prevent thundering herd

## Problem

After PR #38 (Kalshi SDK 3.0.0 upgrade), CI tests consistently fail with HTTP 429 errors. Tests execute ~65 requests/second but Kalshi's Basic tier allows only 20 req/sec.

## Solution

Use the battle-tested `exponential-backoff` library (~2.5M weekly downloads) instead of custom retry logic:

```typescript
const RETRY_OPTIONS = {
  numOfAttempts: 4,
  startingDelay: 100,
  jitter: "full",
  retry: (err) => err instanceof AxiosError && err.response?.status === 429,
};
```

## Test plan

- [ ] All CI checks pass (format, typecheck, lint, test)
- [ ] Tests no longer flake on rate limit errors