### PR TITLE
chore: add .claude/settings.local.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # git worktrees
 .worktrees/
 
+# Claude Code local settings (user-specific)
+.claude/settings.local.json
+
 # MCP config (may contain credentials)
 .mcp.json
 .mcp.json.backup


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` to `.gitignore` to prevent user-specific Claude Code settings from being committed

## Test plan
- [x] File pattern correctly ignores `.claude/settings.local.json`
- [x] Existing tracked files unaffected (file doesn't exist in repo)