### PR TITLE
docs: update README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,179 +1,137 @@
 # Prediction Markets MCP Server
 
-## Project Goal
+## API Reference
 
-Build an MCP server to fetch (and later compare) data across multiple prediction markets.
+Always consult these docs when working with platform APIs:
 
-## Priority Data
+| Platform         | Documentation                                                     |
+| ---------------- | ----------------------------------------------------------------- |
+| Kalshi           | https://docs.kalshi.com/api-reference                             |
+| Polymarket Gamma | https://docs.polymarket.com/developers/gamma-markets-api/overview |
+| Polymarket CLOB  | https://docs.polymarket.com/#clob-api                             |
+| MCP Protocol     | https://modelcontextprotocol.io/specification                     |
 
-1. Available markets/options including resolution terms
-2. Current prices
-3. Current order book
-4. Price history and volume
+## Architecture
 
-## Target Platforms
+```
+index.ts                    Server entry point
+src/
+  clients/
+    kalshi.ts               Kalshi SDK wrapper with bulk fetch
+    polymarket.ts           Gamma API (REST) + CLOB SDK
+  search/
+    cache.ts                Tokenized search with scoring
+    service.ts              Lazy initialization, refresh
+  tools.ts                  MCP tool handlers
+  validation.ts             Zod v4 schemas (generate JSON Schema)
+scripts/
+  bootstrap.ts              Register with Claude Code/Desktop
+  generate-docs.ts          Generate docs/ from source
+  check-docs.ts             CI freshness check
+docs/                       Auto-generated—do not edit
+```
 
-### Kalshi (Priority 1)
+## Platforms
 
-- **SDK**: `kalshi-typescript` (official npm package)
-- **Docs**: https://docs.kalshi.com/welcome
-- **API**: CFTC-regulated, US-based prediction markets
-- **Auth**: API key + RSA private key
-- **Key Methods**:
-  - `getMarkets()` - List markets
-  - `getMarket(ticker)` - Get market details
-  - `getMarketOrderBook(ticker)` - Get order book (bids only)
-  - `getMarketCandlesticks()` - Price history
-  - `getTrades()` - Trade history
-- **Note**: Orderbook returns only bids (no asks) due to binary market reciprocity
-- **Note**: SDK 3.0 uses `MarketApi` (singular). Multivariate events require separate `getMultivariateEvents()` call.
-- **Base URL**: https://api.elections.kalshi.com/trade-api/v2
+### Kalshi
 
-### Polymarket (Priority 2) ✅ Implemented
+- SDK: `kalshi-typescript` v3.0.0
+- Auth: API key + RSA private key
+- Orderbook returns bids only (binary market reciprocity)
+- SDK 3.0 uses `MarketApi` (singular)
+- Base URL: `https://api.elections.kalshi.com/trade-api/v2`
 
-- **Gamma API**: https://gamma-api.polymarket.com (read-only, public)
-- **CLOB API**: https://clob.polymarket.com (orderbook, prices, trades)
-- **Docs**: https://docs.polymarket.com/developers/gamma-markets-api/overview
-- **SDK**: `@polymarket/clob-client@5.0.0` (for CLOB operations)
-- **Auth**: **No authentication required** for all read operations
-- **Key Methods**:
-  - `listMarkets()` - List markets with filtering
-  - `getMarket(slug)` - Get market details by slug
-  - `listEvents()` / `getEvent(slug)` - Event discovery
-  - `listTags()` - Category tags for filtering
-  - `getOrderBook(tokenId)` - Full bid/ask orderbook
-  - `getPrice(tokenId, side)` - Current best price
-  - `getTrades(tokenId)` - Trade history
-  - `getPriceHistory(tokenId)` - Historical price data
-- **Note**: Markets use `slug` for identification. CLOB operations use `token_id` (from market's `clobTokenIds` field)
-- **Note**: Orderbook returns both bids AND asks (unlike Kalshi's bids-only)
+### Polymarket
 
-### Future Consideration
+- Gamma API: market discovery, events, tags (public, no auth)
+- CLOB API: orderbooks, prices, trades
+- SDK: `@polymarket/clob-client` for CLOB operations
+- Markets identified by `slug`; CLOB uses `token_id` from `clobTokenIds`
+- Orderbook returns both bids and asks
 
-- **Manifold Markets**: Has API, uses play money (Mana)
-- **Metaculus**: Academic/forecasting focused, less trading-oriented
+## Search
 
-## Architecture Decision
+Kalshi search uses an in-memory cache:
 
-- **Language**: TypeScript (type safety)
-- **Runtime**: Bun (performance + built-in TypeScript)
-- **Approach**:
-  - Use official Kalshi SDK
-  - Direct REST calls for Polymarket Gamma API
-  - Unified interface layer for MCP tools
-  - Separate client classes per platform
+- Populates on first search (~7 seconds, ~18 API calls)
+- Queries return in <1ms
+- Refresh via `kalshi_cache_stats` with `refresh: true`
+- Scores by field weight: titles (1.0), subtitles (0.8), tickers (0.5)
 
-## MCP Tools to Implement
+## Scripts
 
-1. `list_markets` - List available markets across platforms
-2. `get_market_details` - Get detailed market info including resolution terms
-3. `get_market_price` - Get current prices
-4. `get_orderbook` - Get current order book
-5. `get_price_history` - Get historical price/volume data
-6. `compare_markets` - (Future) Compare similar markets across platforms
+### bootstrap.ts
 
-## Configuration
-
-### Environment Variables
-
-#### Kalshi (Required for Kalshi tools)
+Registers the MCP server with Claude:
 
 ```bash
-# Required for authenticated requests
-KALSHI_API_KEY=your-api-key-id
-KALSHI_PRIVATE_KEY_PATH=/path/to/private-key.pem
-# OR
-KALSHI_PRIVATE_KEY_PEM="-----BEGIN RSA PRIVATE KEY-----\n..."
-
-# Optional - defaults to production API
-KALSHI_BASE_PATH=https://api.elections.kalshi.com/trade-api/v2
-# For demo/testing:
-# KALSHI_BASE_PATH=https://demo-api.kalshi.co/trade-api/v2
+bun run scripts/bootstrap.ts              # Project config (.mcp.json)
+bun run scripts/bootstrap.ts --global     # User config (~/.claude.json)
+bun run scripts/bootstrap.ts --interactive # Prompt for credentials
 ```
 
-#### Polymarket (Optional - works without configuration)
+### generate-docs.ts
 
-All Polymarket read operations are public and require no authentication.
-Optional overrides:
-
-```bash
-# Optional host overrides (defaults shown)
-POLYMARKET_GAMMA_HOST=https://gamma-api.polymarket.com
-POLYMARKET_CLOB_HOST=https://clob.polymarket.com
-POLYMARKET_CHAIN_ID=137  # Polygon mainnet
-```
-
-### MCP Server Configuration
-
-Example configuration for Claude Desktop (`claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "prediction-markets": {
-      "command": "bun",
-      "args": ["run", "/path/to/prediction-mcp/index.ts"],
-      "env": {
-        "KALSHI_API_KEY": "your-api-key",
-        "KALSHI_PRIVATE_KEY_PATH": "/path/to/key.pem"
-      }
-    }
-  }
-}
-```
-
-## MCP Server Best Practices
-
-When implementing or modifying MCP server functionality:
-
-- **Always reference the official specification**: https://modelcontextprotocol.io/specification
-- **Verify against the spec**: Don't assume features are supported without checking
-- **Keep inputSchema minimal**: Only use `type`, `properties`, and `required` fields
-- **Document in descriptions**: Put examples and usage guidance in the `description` field, not as separate schema properties
-
-## Code Style
-
-**Comments:**
-
-- Avoid self-explanatory comments that restate what the code does
-- Focus on **normative state** (what the code is and why) not historical state (what it used to be)
-- Omit changelog-style comments explaining past changes - use git history for that
-- Write comments that add context the code alone cannot convey
-
-## Development Setup
-
-```bash
-# Install dependencies
-bun install
-
-# Run tests
-bun test
-
-# Lint and format
-bun run lint
-bun run format
-
-# Pre-commit hooks are automatically set up via Husky
-```
-
-## Documentation
-
-Documentation in `docs/` is auto-generated from source code. After modifying tools (`src/tools.ts`, `src/validation.ts`) or environment variables, regenerate with:
+Generates documentation from source:
 
 ```bash
 bun run docs:generate
 ```
 
-CI validates docs are in sync via `bun run docs:check`.
+Run after changing `src/tools.ts`, `src/validation.ts`, or environment variables.
 
-**Before creating a PR**, always run `bun run docs:generate` if you modified tools or configuration.
+### check-docs.ts
 
-### Previewing Docs Locally
+Validates docs match source:
 
 ```bash
-# Install mkdocs with material theme (one-time)
-uv tool install mkdocs --with mkdocs-material
-
-# Serve locally
-bun run docs:serve
+bun run docs:check
 ```
+
+CI runs this to catch stale documentation.
+
+## Environment Variables
+
+### Kalshi
+
+```bash
+KALSHI_API_KEY=...
+KALSHI_PRIVATE_KEY_PATH=/path/to/key.pem   # or KALSHI_PRIVATE_KEY_PEM
+KALSHI_BASE_PATH=...                        # optional, defaults to production
+```
+
+### Polymarket
+
+```bash
+POLYMARKET_GAMMA_HOST=...    # default: https://gamma-api.polymarket.com
+POLYMARKET_CLOB_HOST=...     # default: https://clob.polymarket.com
+POLYMARKET_CHAIN_ID=...      # default: 137 (Polygon)
+```
+
+## CI Pipeline
+
+GitHub Actions runs on PRs and pushes to main:
+
+- `format` — Prettier
+- `typecheck` — TypeScript
+- `lint` — ESLint
+- `test` — Bun test with coverage
+- `security` — Dependency audit
+- `secrets` — Gitleaks
+- `docs` — Documentation freshness
+
+All must pass before merge.
+
+## Code Style
+
+Write comments that add context the code cannot convey. Avoid:
+
+- Restating what code does
+- Changelog-style notes (use git history)
+- Self-evident explanations
+
+## MCP Best Practices
+
+- Reference the spec: https://modelcontextprotocol.io/specification
+- Keep `inputSchema` minimal: `type`, `properties`, `required` only
+- Put examples in the tool `description`, not schema properties

--- a/README.md
+++ b/README.md
@@ -1,51 +1,49 @@
 # Prediction Markets MCP Server
 
-MCP server for fetching prediction market data from Kalshi (Polymarket planned).
+An MCP server that fetches prediction market data from Kalshi and Polymarket.
 
 ## Features
 
-- **Kalshi integration** — list markets, prices, orderbooks, and trade history
-- **Type-safe** — TypeScript with official Kalshi SDK
-- **MCP protocol** — standard Model Context Protocol server
-- **Auto-retry** — exponential backoff on rate limits (HTTP 429)
+- **Kalshi and Polymarket** — Query markets, orderbooks, prices, and trade history
+- **Full-text search** — Find Kalshi events and markets by keyword
+- **Rate limit handling** — Automatic retry with exponential backoff
 
-## Installation
+## Quick Start
 
 ```bash
 bun install
+bun run scripts/bootstrap.ts --interactive
 ```
+
+The bootstrap script registers this server with Claude Code or Claude Desktop and prompts for your Kalshi credentials.
 
 ## Configuration
 
-### Environment Variables
+### Kalshi
+
+Kalshi requires API credentials for authenticated requests:
 
 ```bash
-# Kalshi API credentials (required for authenticated requests)
 KALSHI_API_KEY=your-api-key-id
 KALSHI_PRIVATE_KEY_PATH=/path/to/private-key.pem
-# OR provide the key directly as PEM string
-KALSHI_PRIVATE_KEY_PEM="-----BEGIN RSA PRIVATE KEY-----..."
-
-# Optional: Override API endpoint (defaults to production)
-KALSHI_BASE_PATH=https://api.elections.kalshi.com/trade-api/v2
 ```
 
-**Getting Kalshi API credentials:**
+Get credentials at [kalshi.com/profile/api](https://kalshi.com/profile/api).
 
-1. Sign up at https://kalshi.com
-2. Generate API key at https://kalshi.com/profile/api
-3. Download your private key file
+### Polymarket
 
-### MCP Server Setup
+Polymarket tools work without authentication—all read operations are public.
 
-Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```json
 {
   "mcpServers": {
     "prediction-markets": {
       "command": "bun",
-      "args": ["run", "/absolute/path/to/prediction-mcp/index.ts"],
+      "args": ["run", "/path/to/prediction-mcp/index.ts"],
       "env": {
         "KALSHI_API_KEY": "your-api-key",
         "KALSHI_PRIVATE_KEY_PATH": "/path/to/key.pem"
@@ -55,93 +53,53 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
 }
 ```
 
-## Available Methods
+## Available Tools
 
-### Kalshi Client
+See [docs/tools/reference.md](docs/tools/reference.md) for the full tool reference with parameters.
 
-```typescript
-import { KalshiClient } from "./src/clients/kalshi";
-
-const client = new KalshiClient();
-
-// List markets
-const markets = await client.listMarkets({ status: "open", limit: 10 });
-
-// Get market details
-const market = await client.getMarketDetails("TICKER");
-
-// Get orderbook (bids only - binary market reciprocity)
-const orderbook = await client.getOrderBook("TICKER");
-
-// Get trade history
-const trades = await client.getTrades({ ticker: "TICKER", limit: 100 });
-```
+Run `bun run docs:generate` after modifying tools to keep documentation in sync.
 
 ## Development
 
 ```bash
-# Run tests
-bun test
-
-# Type check
-bun run typecheck
-
-# Lint code
-bun run lint
-bun run lint:fix
-
-# Format code
-bun run format
-bun run format:check
-
-# Generate documentation (after changing tools or env vars)
-bun run docs:generate
-
-# Preview docs locally (requires uv: https://docs.astral.sh/uv/)
-uv tool install mkdocs --with mkdocs-material
-bun run docs:serve
+bun test              # Run tests
+bun run typecheck     # Type check
+bun run lint          # Lint
+bun run format        # Format
 ```
 
-### Pre-commit Hooks
+Pre-commit hooks run these checks automatically via Husky.
 
-Husky automatically runs type checking, linting, and formatting on git commits via lint-staged.
+### Documentation
+
+```bash
+bun run docs:generate  # Regenerate docs from source
+bun run docs:check     # Verify docs match source (CI uses this)
+bun run docs:serve     # Preview at localhost:8000
+```
 
 ## Project Structure
 
 ```
-.
-├── index.ts                   # MCP server entry point
-├── src/
-│   ├── clients/
-│   │   └── kalshi.ts          # Kalshi API client wrapper
-│   ├── tools.ts               # MCP tool definitions
-│   ├── tools.test.ts          # Integration tests
-│   └── validation.ts          # Zod schemas for tool arguments
-├── scripts/
-│   ├── bootstrap.ts           # Claude Desktop registration
-│   ├── generate-docs.ts       # Documentation generator
-│   └── check-docs.ts          # CI doc freshness check
-├── docs/                      # Auto-generated documentation
-├── package.json
-├── tsconfig.json
-└── mkdocs.yml
+index.ts              # Server entry point
+src/
+  clients/
+    kalshi.ts         # Kalshi API client
+    polymarket.ts     # Polymarket Gamma + CLOB client
+  search/
+    cache.ts          # Search index
+    service.ts        # Search lifecycle
+  tools.ts            # MCP tool handlers
+  validation.ts       # Zod schemas
+scripts/
+  bootstrap.ts        # MCP registration
+  generate-docs.ts    # Doc generator
+  check-docs.ts       # Doc freshness check
 ```
 
-## Tech Stack
+## Links
 
-- **Runtime**: Bun (fast TypeScript execution)
-- **Language**: TypeScript
-- **Testing**: Bun's built-in test runner
-- **Linting**: ESLint with TypeScript support
-- **Formatting**: Prettier
-- **Git Hooks**: Husky + lint-staged
-
-## API Documentation
-
-- **Kalshi API Docs**: https://docs.kalshi.com
-- **Kalshi TypeScript SDK**: https://www.npmjs.com/package/kalshi-typescript
-- **MCP Protocol**: https://modelcontextprotocol.io
-
-## Contributing & Roadmap
-
-See [TODO.md](./TODO.md) for the full roadmap, planned features, and contribution opportunities.
+- [Tool Reference](docs/tools/reference.md)
+- [Kalshi API](https://docs.kalshi.com/api-reference)
+- [Polymarket API](https://docs.polymarket.com)
+- [MCP Protocol](https://modelcontextprotocol.io)


### PR DESCRIPTION
## Summary

- Simplify README by removing tool tables that go stale
- Point to auto-generated `docs/tools/reference.md` instead
- Add Quick Start section with bootstrap command
- Move authoritative API reference links to top of CLAUDE.md
- Document architecture, scripts, search system, and CI pipeline

## Changes

**README.md**
- Removed verbose tool tables (now links to generated docs)
- Added Quick Start with `bootstrap.ts --interactive`
- Streamlined configuration section
- Cleaner project structure diagram

**CLAUDE.md**
- API Reference table at top (Kalshi, Polymarket Gamma/CLOB, MCP)
- Architecture overview with file descriptions
- Platform-specific notes (SDK versions, auth, quirks)
- Script documentation (bootstrap, generate-docs, check-docs)
- CI pipeline summary
- Code style and MCP best practices

## Motivation

Tool lists in README go stale. The `docs:generate` script already produces accurate tool documentation from source. README should point there instead of duplicating.

CLAUDE.md should surface API docs prominently so Claude and agents reference authoritative sources during development.

## Test Plan

- [x] `bun run format` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run docs:check` passes (docs in sync)