### PR TITLE
feat(logging): add strategic logging for observability

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -103,6 +103,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   } catch (error) {
     const classified = classifyError(error);
 
+    logger.error(
+      { tool: name, errorCode: classified.code, message: classified.message },
+      "Tool execution failed",
+    );
+
     return {
       content: [
         {


### PR DESCRIPTION
## Summary

- Add targeted logging at key operational points for debugging and observability
- Follow "strategic, not superfluous" approach — log at boundaries, not everywhere
- Uses existing Pino logger infrastructure via centralized `src/logger.ts`

## Changes

| Location | Level | Purpose |
|----------|-------|---------|
| `search/service.ts` | info | Cache populate/refresh lifecycle with timing metrics |
| `clients/kalshi.ts` | warn | Rate limit (429) retry visibility |
| `clients/polymarket.ts` | warn | Rate limit (429) retry visibility |
| `index.ts` | error | Tool execution failures with classified error context |

## Example Output

```json
{"level":30,"msg":"Populating search cache from Kalshi API..."}
{"level":30,"events":3465,"markets":24594,"elapsedMs":5735,"msg":"Search cache populated"}
{"level":40,"attempt":1,"maxAttempts":4,"status":429,"msg":"Kalshi rate limited, retrying"}
{"level":50,"tool":"kalshi_get_market","errorCode":"NotFoundError","message":"Market not found","msg":"Tool execution failed"}
```

## Log Field Design

- **`elapsedMs`** — Numeric milliseconds for easy aggregation/alerting (vs string `"5.7s"`)
- **`status: 429`** — Explicit status code for filtering logs by HTTP status
- **Structured objects** — All context in machine-parseable fields

## Test Plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes (176 tests)
- [x] Pre-commit hooks pass (ESLint, Prettier, TypeScript)

## Related

- #58 — Future: MCP protocol-level logging (sends logs to clients via `notifications/message`)